### PR TITLE
Use enrol (UK spelling) instead of enroll (US spelling)

### DIFF
--- a/lang/en/local_kopere_dashboard.php
+++ b/lang/en/local_kopere_dashboard.php
@@ -210,7 +210,7 @@ $string['reports_groupnode'] = 'Group Mode';
 $string['reports_groupname'] = 'Group Name';
 $string['reports_datastudents'] = 'Student Data';
 $string['reports_datacourses'] = 'Course Data';
-$string['reports_coursecreated'] = 'Date of enrollment';
+$string['reports_coursecreated'] = 'Date of enrolment';
 $string['reports_activitiescomplete'] = 'Activities Completed';
 $string['reports_activitiesassigned'] = 'Assigned Activities';
 $string['reports_coursecompleted'] = 'Course completed';
@@ -233,10 +233,10 @@ $string['dashboard_grade_incourse'] = 'in course <a href="?Courses::details&cour
 $string['dashboard_grade_of'] = 'of';
 $string['dashboard_grade_text'] = 'Received note {$a->grade} in {$a->evaluation}';
 $string['dashboard_grade_in'] = 'In';
-$string['dashboard_enrol_title'] = 'Last Enrollment';
-$string['dashboard_enrol_inactive'] = 'the registration is inactive';
-$string['dashboard_enrol_active'] = 'the registration is active';
-$string['dashboard_enrol_text'] = 'You have enrolled in the course <a href="?Courses::details&courseid={$a->courseid}">{$a->fullname}</a> and';
+$string['dashboard_enrol_title'] = 'Last Enrolment';
+$string['dashboard_enrol_inactive'] = 'the enrolment is inactive';
+$string['dashboard_enrol_active'] = 'the enrolment is active';
+$string['dashboard_enrol_text'] = 'You have enroled in the course <a href="?Courses::details&courseid={$a->courseid}">{$a->fullname}</a> and';
 $string['dashboard_enrol_lastmodifield'] = 'Last change in';
 
 // Notifications


### PR DESCRIPTION
Use enrol (UK spelling) instead of enroll (US spelling). Because Moodle language is Australian English, 99.9% = UK English.

See https://docs.moodle.org/34/en/Language_FAQ#Which_is_the_official_language_for_Moodle.3F

See also http://www.grammar.com/enrol_vs._enroll