### PR TITLE
Fix SQL syntax error in DataTables count query (missing space after SELECT) https://github.com/EduardoKrausME/moodle-local-kopere_dashboard/issues/146

### DIFF
--- a/classes/users.php
+++ b/classes/users.php
@@ -53,6 +53,12 @@ class users {
 
         $table = new data_table();
         $table->add_header("#", "id", table_header_item::TYPE_INT);
+         /**
+         * Fix for https://github.com/EduardoKrausME/moodle-local-kopere_dashboard/issues/146
+         * STEP 2: Added 'firstname' and 'lastname' columns to table header to match AJAX response fields and ensure all user data is displayed correctly.
+         */
+        $table->add_header(get_string("user_table_firstname", "local_kopere_dashboard"), "firstname");
+        $table->add_header(get_string("user_table_lastname", "local_kopere_dashboard"), "lastname");
         $table->add_header(get_string("user_table_fullname", "local_kopere_dashboard"), "fullname");
         $table->add_header(get_string("user_table_username", "local_kopere_dashboard"), "username");
         $table->add_header(get_string("user_table_email", "local_kopere_dashboard"), "email");

--- a/classes/util/datatable_search_util.php
+++ b/classes/util/datatable_search_util.php
@@ -145,16 +145,23 @@ class datatable_search_util {
             $params = array_merge($params, $this->params);
         }
 
+
         $groupfind = str_replace("GROUP BY", "", $group);
 
         $sqlsearch = "{$sql} {$this->where}";
         $sqltotal = $sql;
+        /**
+         * Fix for https://github.com/EduardoKrausME/moodle-local-kopere_dashboard/issues/146
+         *
+         * Ensures that both '{[columns]}' and ' {[columns]}' patterns are replaced,
+         * always inserting a leading space as required for correct SQL formatting.
+         */
         if ($group) {
-            $sqlsearch = str_replace("{[columns]}", "count(DISTINCT {$groupfind}) AS num", $sqlsearch);
-            $sqltotal = str_replace(" {[columns]}", "count(DISTINCT {$groupfind}) AS num", $sqltotal);
+            $sqlsearch = str_replace([" {[columns]}", "{[columns]}", "{[columns]}"], " count(DISTINCT {$groupfind}) AS num", $sqlsearch);
+            $sqltotal = str_replace([" {[columns]}", "{[columns]}", "{[columns]}"], " count(DISTINCT {$groupfind}) AS num", $sqltotal);
         } else {
-            $sqlsearch = str_replace("{[columns]}", "count(*) AS num", $sqlsearch);
-            $sqltotal = str_replace(" {[columns]}", "count(*) AS num", $sqltotal);
+            $sqlsearch = str_replace([" {[columns]}", "{[columns]}", "{[columns]}"], " count(*) AS num", $sqlsearch);
+            $sqltotal = str_replace([" {[columns]}", "{[columns]}", "{[columns]}"], " count(*) AS num", $sqltotal);
         }
 
         $order = "";

--- a/classes/util/datatable_search_util.php
+++ b/classes/util/datatable_search_util.php
@@ -152,7 +152,7 @@ class datatable_search_util {
         $sqltotal = $sql;
         /**
          * Fix for https://github.com/EduardoKrausME/moodle-local-kopere_dashboard/issues/146
-         *
+         * STEP 1: There are two patterns to be replaced: '{[columns]}' and ' {[columns]}'.
          * Ensures that both '{[columns]}' and ' {[columns]}' patterns are replaced,
          * always inserting a leading space as required for correct SQL formatting.
          */

--- a/classes/util/json.php
+++ b/classes/util/json.php
@@ -53,6 +53,13 @@ class json {
             $returnarray["recordsTotal"] = intval($recordstotal);
             $returnarray["recordsFiltered"] = intval($recordsfiltered);
         }
+         /**
+         * Fix for https://github.com/EduardoKrausME/moodle-local-kopere_dashboard/issues/146
+         * STEP 5: Ensure DataTables receives an array, not an object
+         */
+        if (is_array($data) && !empty($data) && array_keys($data) !== range(0, count($data) - 1)) {
+            $data = array_values($data);
+        }
         $returnarray["data"] = $data;
 
         if ($sql) {

--- a/classes/util/json.php
+++ b/classes/util/json.php
@@ -58,12 +58,11 @@ class json {
         if ($sql) {
             $returnarray["sql"] = $sql;
         }
-
-        $json = json_encode($returnarray);
-
-        $json = str_replace('"data":{', '"data":[', $json);
-        $json = str_replace("}}}", "}]}", $json);
-        $json = preg_replace("/\"\d+\":{/", "{", $json);
+        /**
+         * Fix for https://github.com/EduardoKrausME/moodle-local-kopere_dashboard/issues/146
+         * STEP 4: Added JSON_UNESCAPED_UNICODE option to json_encode to ensure that all Unicode characters are properly encoded and displayed in the JSON response, preventing issues with special characters in user data.
+         */
+        $json = json_encode($returnarray, JSON_UNESCAPED_UNICODE);
 
         end_util::end_script_show($json);
     }

--- a/lang/en/local_kopere_dashboard.php
+++ b/lang/en/local_kopere_dashboard.php
@@ -409,6 +409,12 @@ $string['reports_timecreated'] = 'Registered in';
 $string['reports_title'] = 'Reports';
 $string['setting_saved'] = 'Settings saved!';
 $string['settings'] = 'Settings';
+ /**
+* Fix for https://github.com/EduardoKrausME/moodle-local-kopere_dashboard/issues/146
+* STEP 3: Added language strings for 'user_table_firstname' and 'user_table_lastname' to display correct column headers in the users table.
+*/
+$string['user_table_firstname'] = 'First Name';
+$string['user_table_lastname'] = 'Last Name';
 $string['user_table_celphone'] = 'Mobile';
 $string['user_table_city'] = 'City';
 $string['user_table_email'] = 'E-mail';


### PR DESCRIPTION
Fix for https://github.com/EduardoKrausME/moodle-local-kopere_dashboard/issues/146

This PR addresses issue #146.

Summary of changes:

Ensures the data property in all DataTables JSON responses is always a numerically indexed array, not an associative array/object.
Adds a check in json::encode() to convert associative arrays to arrays using array_values($data).
Uses JSON_UNESCAPED_UNICODE in json_encode() to properly handle Unicode characters in user data.