### PR TITLE
Fix Users list showing only 1 record (revert dc91180 + space fix)

### DIFF
--- a/classes/util/datatable_search_util.php
+++ b/classes/util/datatable_search_util.php
@@ -136,7 +136,7 @@ class datatable_search_util {
      * @param null $functionbeforereturn
      * @throws Exception
      */
-    public function execute_sql_and_return($sql, $group = "", $params = null, $functionbeforereturn = null, $countparams = null) {
+    public function execute_sql_and_return($sql, $group = null, $params = null, $functionbeforereturn = null) {
         global $DB;
 
         if ($params == null) {
@@ -145,48 +145,46 @@ class datatable_search_util {
             $params = array_merge($params, $this->params);
         }
 
-        $order = "";
-        if ($this->order) {
-            $order = "ORDER BY {$this->order} {$this->orderdir}";
+        $groupfind = str_replace("GROUP BY", "", $group);
+
+        $sqlsearch = "{$sql} {$this->where}";
+        $sqltotal = $sql;
+        if ($group) {
+            $sqlsearch = str_replace("{[columns]}", "count(DISTINCT {$groupfind}) AS num", $sqlsearch);
+            $sqltotal = str_replace(" {[columns]}", " count(DISTINCT {$groupfind}) AS num", $sqltotal);
+        } else {
+            $sqlsearch = str_replace("{[columns]}", "count(*) AS num", $sqlsearch);
+            $sqltotal = str_replace(" {[columns]}", " count(*) AS num", $sqltotal);
         }
 
-        if ($group || $countparams) {
-            if (!$countparams && $group) {
-                $countparams = str_replace("GROUP BY", "", $group);
-            }
-            $sqlcolumns = str_replace("{[columns]}", "count(DISTINCT {$countparams}) AS num, {[columns]}", $sql);
-            $sql = str_replace("{[columns]}", "count(DISTINCT {$countparams}) AS num", $sql);
-        } else {
-            $sqlcolumns = str_replace("{[columns]}", "count(*) AS num, {[columns]}", $sql);
-            $sql = str_replace("{[columns]}", "count(*) AS num", $sql);
+        $order = "";
+        if ($this->order) {
+            $order = "ORDER BY $this->order $this->orderdir";
         }
 
         if ($DB->get_dbfamily() == "postgres") {
-            $sqlsearch      = "{$sqlcolumns} \n{$this->where} \n{$group} \n{$order} \nLIMIT {$this->length} OFFSET {$this->start}";
-            $sqlsearchcount = "{$sql}        \n{$this->where} \n{$group} \n{$order}";
-            $sqltotal       = "{$sql}                         \n{$group} \n{$order}";
+            $sqlreturn = "{$sql} $this->where $group {$order} LIMIT $this->length OFFSET $this->start";
         } else {
-            $sqlsearch      = "{$sqlcolumns} \n{$this->where} \n{$group} \n{$order} \nLIMIT {$this->start}, {$this->length}";
-            $sqlsearchcount = "{$sql}        \n{$this->where} \n{$group} \n{$order}";
-            $sqltotal       = "{$sql}                         \n{$group} \n{$order}";
+            $sqlreturn = "{$sql} $this->where $group {$order} LIMIT $this->start, $this->length";
         }
 
-        echo '<pre>';
-        $sqlsearch = str_replace("{[columns]}", implode(", ", $this->columnselect), $sqlsearch);
+        $sqlreturn = str_replace("{[columns]}", implode(", ", $this->columnselect), $sqlreturn);
 
-        $result = $DB->get_records_sql($sqlsearch, $params);
+        $result = $DB->get_records_sql($sqlreturn, $params);
         $total = $DB->get_record_sql($sqltotal, $params);
-        $searchnum = $total->num;
+        $totalnum = $total->num;
 
         if ($this->where) {
-            $search = $DB->get_record_sql($sqlsearchcount, $params);
+            $search = $DB->get_record_sql($sqlsearch, $params);
             $searchnum = $search->num;
+        } else {
+            $searchnum = $totalnum;
         }
 
         if ($functionbeforereturn) {
             $result = call_user_func($functionbeforereturn, $result);
         }
 
-        json::encode($result, $total->num, $searchnum, $sqlsearch);
+        json::encode($result, $totalnum, $searchnum, $sqlreturn);
     }
 }


### PR DESCRIPTION
Hi! Thanks for maintaining this plugin.

Commit dc91180 fixed the original SELECTcount(*) syntax error, but introduced a new issue: combining count(*) with data columns in a single query causes all rows to collapse into one result, because count(*) without GROUP BY is an aggregate. The Users list and Helpdesk user selector only show 1 record instead of all users.

This PR reverts that rewrite and applies a simpler fix: just adding the missing leading space in the str_replace replacement string for $sqltotal. This preserves the original separate-query structure which works correctly.

Changes:

- Restored separate queries for data and count (reverts dc91180)
- Fixed the missing space: " count(*) AS num" instead of "count(*) AS num"
- Same fix applied to the count(DISTINCT) branch
- Removed a stray echo statement left from debugging

Tested on Moodle 5.0 — Users list and Helpdesk user selector both load all users correctly.